### PR TITLE
Mejoras en manejo de estado y validaciones de pedidos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,124 @@
 # pedidos-api
+Gestor de Pedidos – Backend
+1. Resumen del proyecto
+
+API REST para la gestión de pedidos con CRUD completo, validaciones estrictas y documentación Swagger/OpenAPI.
+
+2. Tecnologías
+
+Java 21
+
+Spring Boot 3.2.x
+
+Spring Data JPA
+
+Jakarta Bean Validation
+
+Springdoc OpenAPI 2.3.x
+
+3. Funcionalidades implementadas
+
+CRUD de Pedidos
+
+Crear (POST /api/pedidos)
+
+Listar todos (GET /api/pedidos)
+
+Obtener por ID (GET /api/pedidos/{id})
+
+Actualizar (PUT /api/pedidos/{id})
+
+Actualizar solo estado (PATCH /api/pedidos/{id}/estado)
+
+Eliminar (DELETE /api/pedidos/{id})
+
+DTOs y Validaciones
+
+PedidoDTO y EstadoDTO con validaciones: @NotBlank, @NotNull, @Size
+
+Uso de enum Estado (PENDIENTE, EN_PROCESO, COMPLETADO) para restringir valores válidos
+
+Errores claros en caso de datos inválidos (IllegalArgumentException, PedidoNotFoundException)
+
+Service y Logging
+
+Métodos transaccionales (@Transactional) para update/delete
+
+Logging con SLF4J (info, debug, error) para trazabilidad
+
+Swagger / OpenAPI
+
+Documentación completa con ejemplos y valores permitidos para enums
+
+@Schema para DTOs, @Operation y @ApiResponse para endpoints
+
+Ajustes de versión y dependencias para que /v3/api-docs funcione correctamente
+
+4. Problemas solucionados durante el desarrollo
+
+Springdoc no generaba documentación correctamente → solución: Spring Boot 3.2.x + Springdoc 2.3.x
+
+Validaciones sobre enum generaban errores → reemplazado @Pattern por enum y @NotNull
+
+Antes se podían ingresar estados inválidos → ahora solo acepta los definidos en el enum
+
+Logging detallado para operaciones y errores
+
+Limpieza de proyecto y sincronización Maven para que Swagger y la app funcionen correctamente
+
+5. Ejemplos de Requests / Responses
+
+Crear Pedido
+
+POST /api/pedidos
+{
+  "descripcion": "Compra de insumos",
+  "estado": "PENDIENTE"
+}
+
+
+Response 200
+
+{
+  "id": 1,
+  "descripcion": "Compra de insumos",
+  "estado": "PENDIENTE",
+  "fechaCreacion": "2025-08-28T20:21:02.245Z"
+}
+
+
+Actualizar solo Estado
+
+PATCH /api/pedidos/1/estado
+{
+  "estado": "EN_PROCESO"
+}
+
+
+Response 200
+
+{
+  "id": 1,
+  "descripcion": "Compra de insumos",
+  "estado": "EN_PROCESO",
+  "fechaCreacion": "2025-08-28T20:21:02.245Z"
+}
+
+
+Error de validación
+
+POST /api/pedidos
+{
+  "descripcion": "",
+  "estado": null
+}
+
+
+Response 400
+
+{
+  "timestamp": "2025-08-28T20:25:00.000Z",
+  "status": 400,
+  "error": "Error de validación",
+  "message": "La descripción no puede estar vacía"
+}

--- a/src/main/java/com/pedidos/pedidos_api/dto/EstadoDTO.java
+++ b/src/main/java/com/pedidos/pedidos_api/dto/EstadoDTO.java
@@ -1,24 +1,23 @@
 package com.pedidos.pedidos_api.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
-import jakarta.validation.constraints.Pattern;
+import com.pedidos.pedidos_api.model.Estado;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 public class EstadoDTO {
 
-    @NotBlank(message = "El estado no puede estar vacío")
-    @Size(max = 50, message = "El estado no puede superar 50 caracteres")
-    @Pattern(regexp = "PENDIENTE|EN_PROCESO|COMPLETADO",
-             message = "El estado debe ser PENDIENTE, EN_PROCESO o COMPLETADO")
-    private String estado;
+    @NotNull(message = "El estado no puede estar vacío")
+    @Schema(description = "Estado del pedido", example = "PENDIENTE", allowableValues = {"PENDIENTE", "EN_PROCESO", "COMPLETADO"})
+    private Estado estado;
 
     // Getter
-    public String getEstado() {
+    public Estado getEstado() {
         return estado;
     }
 
     // Setter
-    public void setEstado(String estado) {
+    public void setEstado(Estado estado) {
         this.estado = estado;
     }
 }

--- a/src/main/java/com/pedidos/pedidos_api/dto/PedidoDTO.java
+++ b/src/main/java/com/pedidos/pedidos_api/dto/PedidoDTO.java
@@ -2,6 +2,10 @@ package com.pedidos.pedidos_api.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import com.pedidos.pedidos_api.model.Estado;
+import jakarta.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public class PedidoDTO {
 
@@ -9,9 +13,9 @@ public class PedidoDTO {
     @Size(max = 255, message = "La descripción no puede superar 255 caracteres")
     private String descripcion;
 
-    @NotBlank(message = "El estado no puede estar vacío")
-    @Size(max = 50, message = "El estado no puede superar 50 caracteres")
-    private String estado;
+    @Schema(description = "Estado del pedido", example = "PENDIENTE", allowableValues = {"PENDIENTE", "EN_PROCESO", "COMPLETADO"})
+    @NotNull(message = "El estado no puede estar vacío")
+    private Estado estado;
 
     // Getters y setters
     public String getDescripcion() {
@@ -22,11 +26,11 @@ public class PedidoDTO {
         this.descripcion = descripcion;
     }
 
-    public String getEstado() {
+    public Estado getEstado() {
         return estado;
     }
 
-    public void setEstado(String estado) {
+    public void setEstado(Estado estado) {
         this.estado = estado;
     }
 }

--- a/src/main/java/com/pedidos/pedidos_api/model/Estado.java
+++ b/src/main/java/com/pedidos/pedidos_api/model/Estado.java
@@ -1,0 +1,7 @@
+package com.pedidos.pedidos_api.model;
+
+public enum Estado {
+    PENDIENTE,
+    EN_PROCESO,
+    COMPLETADO
+}

--- a/src/main/java/com/pedidos/pedidos_api/model/Pedido.java
+++ b/src/main/java/com/pedidos/pedidos_api/model/Pedido.java
@@ -20,7 +20,8 @@ public class Pedido {
     private String descripcion;
 
     @Column(nullable = false)
-    private String estado;
+    @Enumerated(EnumType.STRING)
+    private Estado estado;
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @Column(name = "fecha_creacion")
@@ -33,8 +34,8 @@ public class Pedido {
     public String getDescripcion() { return descripcion; }
     public void setDescripcion(String descripcion) { this.descripcion = descripcion; }
 
-    public String getEstado() { return estado; }
-    public void setEstado(String estado) { this.estado = estado; }
+    public Estado getEstado() { return estado; }
+    public void setEstado(Estado estado) { this.estado = estado; }
 
     public LocalDateTime getFechaCreacion() { return fechaCreacion; }
     public void setFechaCreacion(LocalDateTime fechaCreacion) { this.fechaCreacion = fechaCreacion; }

--- a/src/main/java/com/pedidos/pedidos_api/service/PedidoService.java
+++ b/src/main/java/com/pedidos/pedidos_api/service/PedidoService.java
@@ -1,17 +1,19 @@
 package com.pedidos.pedidos_api.service;
 
-import com.pedidos.pedidos_api.dto.PedidoDTO;
-import com.pedidos.pedidos_api.exception.PedidoNotFoundException;
-import com.pedidos.pedidos_api.model.Pedido;
-import com.pedidos.pedidos_api.repository.PedidoRepository;
+import java.util.List;
+import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
-import java.util.List;
-import java.util.Optional;
+import com.pedidos.pedidos_api.dto.PedidoDTO;
+import com.pedidos.pedidos_api.exception.PedidoNotFoundException;
+import com.pedidos.pedidos_api.model.Estado;
+import com.pedidos.pedidos_api.model.Pedido;
+import com.pedidos.pedidos_api.repository.PedidoRepository;
 
 
 @Service
@@ -57,7 +59,7 @@ public class PedidoService {
 
     // PATCH - actualizar solo estado
     @Transactional
-    public Pedido updatePedidoStatus(Long id, String estado) {
+    public Pedido updatePedidoStatus(Long id, Estado estado) {
         logger.info("Actualizando estado del pedido con id {} a '{}'", id, estado);
         return pedidoRepository.findById(id).map(pedido -> {
             pedido.setEstado(estado);
@@ -68,6 +70,7 @@ public class PedidoService {
             return new PedidoNotFoundException(id);
         });
     }
+
 
     // DELETE
     @Transactional
@@ -82,21 +85,22 @@ public class PedidoService {
     // Métodos auxiliares privados
 
     private void mapDTOToPedido(PedidoDTO dto, Pedido pedido) {
-    // Solo asigna valores no nulos y elimina espacios en blanco
+        // Solo asigna valores no nulos y elimina espacios en blanco
         if (dto.getDescripcion() != null && !dto.getDescripcion().isBlank()) {
             pedido.setDescripcion(dto.getDescripcion().trim());
         }
-        if (dto.getEstado() != null && !dto.getEstado().isBlank()) {
-            pedido.setEstado(dto.getEstado().trim());
+        if (dto.getEstado() != null) {
+            pedido.setEstado(dto.getEstado()); // ahora es enum, se asigna directo
         }
-     }
+    }
+
 
     private void validatePedidoDTO(PedidoDTO dto) {
         // Validación estricta para asegurar datos válidos
         if (!StringUtils.hasText(dto.getDescripcion())) {
             throw new IllegalArgumentException("La descripción no puede estar vacía");
         }
-        if (!StringUtils.hasText(dto.getEstado())) {
+        if (dto.getEstado() == null) {
             throw new IllegalArgumentException("El estado no puede estar vacío");
         }
     }


### PR DESCRIPTION
Descripción detallada:

Cambio de validación de estados:

Se reemplazó el uso de String por enum Estado (PENDIENTE, EN_PROCESO, COMPLETADO) en PedidoDTO y EstadoDTO.

Esto asegura que los pedidos solo puedan tener valores válidos y evita errores de JSON parse.

Actualización de endpoints:

POST /api/pedidos ahora recibe PedidoDTO con Estado enum.

PATCH /api/pedidos/{id}/estado usa EstadoDTO para actualizar solo el estado del pedido.

Validaciones mejoradas:

Se eliminaron @Pattern y @NotBlank sobre el enum, se reemplazó por @NotNull.

Se agregaron mensajes claros para los errores de validación.

Logging y trazabilidad:

Se mantuvieron logs en PedidoService para creación, actualización y errores de pedidos.

Swagger/OpenAPI:

Se agregó @Schema(allowableValues = {...}) en PedidoDTO y EstadoDTO para documentar los valores válidos de enum en la API.

Nota: Swagger sigue mostrando input de texto en JSON, pero los valores válidos están documentados y validados al enviar el request.

Problemas solucionados:

Evitado ingreso de estados inválidos.

Evitado errores de deserialización JSON con valores de enum no permitidos.